### PR TITLE
Startup command is not working

### DIFF
--- a/1.0/startup/init_container.sh
+++ b/1.0/startup/init_container.sh
@@ -11,9 +11,9 @@ sed -i "s/SSH_PORT/$SSH_PORT/g" /etc/ssh/sshd_config
 sed -i "s/PORT/$PORT/g" /etc/nginx/sites-available/mysite
 ln -s /etc/nginx/sites-available/mysite /etc/nginx/sites-enabled/mysite
 
-echo "Restarting nginx..."
-service nginx restart
-
+echo "Executing the script: " $@
 exec "$@"
 
-
+echo "Restarting nginx..."
+nginx -t
+service nginx restart 


### PR DESCRIPTION
In the init_script.sh, after nginx starts up, the custom script does not get called. Changed the logic to call the script first. It would be necessary to also start Nginx in the custom startup script. 